### PR TITLE
Fix PR2 calibration by using hacked version of urdf_parser_py by overwriting PYTHONPATH in the shell scripts.

### DIFF
--- a/pr2_calibration_launch/estimate_params/estimate_pr2_beta_urdf.sh
+++ b/pr2_calibration_launch/estimate_params/estimate_pr2_beta_urdf.sh
@@ -16,6 +16,9 @@ rm robot_calibrated.xml
 echo "Success"
 
 roslaunch pr2_calibration_launch head_then_arms_params.launch
+# use hacked version of urdf_parser_py
+export PYTHONPATH=`rospack find pr2_calibration_launch`/pr2_urdf_parser_py:$PYTHONPATH
+
 rosrun calibration_estimation multi_step_cov_estimator.py /tmp/pr2_calibration/cal_measurements.bag /tmp/pr2_calibration __name:=cal_cov_estimator
 
 est_return_val=$?

--- a/pr2_calibration_launch/estimate_params/estimate_pr2_se_beta_urdf.sh
+++ b/pr2_calibration_launch/estimate_params/estimate_pr2_se_beta_urdf.sh
@@ -15,6 +15,8 @@ fi
 rm robot_calibrated.xml
 echo "Success"
 
+export PYTHONPATH=`rospack find pr2_calibration_launch`/pr2_urdf_parser_py:$PYTHONPATH
+
 roslaunch pr2_calibration_launch pr2_se_params.launch
 rosrun calibration_estimation multi_step_cov_estimator.py /tmp/pr2_calibration/cal_measurements.bag /tmp/pr2_calibration __name:=cal_cov_estimator
 

--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/sdf.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/sdf.py
@@ -1,0 +1,121 @@
+from urdf_parser_py.xml_reflection.basics import *
+import urdf_parser_py.xml_reflection as xmlr
+
+# What is the scope of plugins? Model, World, Sensor?
+
+xmlr.start_namespace('sdf')
+
+class Pose(xmlr.Object):
+	def __init__(self, vec=None, extra=None):
+		self.xyz = None
+		self.rpy = None
+		if vec is not None:
+			assert isinstance(vec, list)
+			count = len(vec)
+			if len == 3:
+				xyz = vec
+			else:
+				self.from_vec(vec)
+		elif extra is not None:
+			assert xyz is None, "Cannot specify 6-length vector and 3-length vector"
+			assert len(extra) == 3, "Invalid length"
+			self.rpy = extra
+	
+	def from_vec(self, vec):
+		assert len(vec) == 6, "Invalid length"
+		self.xyz = vec[:3]
+		self.rpy = vec[3:6]
+	
+	def as_vec(self):
+		xyz = self.xyz if self.xyz else [0, 0, 0]
+		rpy = self.rpy if self.rpy else [0, 0, 0]
+		return xyz + rpy
+	
+	def read_xml(self, node):
+		# Better way to do this? Define type?
+		vec = get_type('vector6').read_xml(node)
+		self.load_vec(vec)
+	
+	def write_xml(self, node):
+		vec = self.as_vec()
+		get_type('vector6').write_xml(node, vec)
+	
+	def check_valid(self):
+		assert self.xyz is not None or self.rpy is not None
+
+name_attribute = xmlr.Attribute('name', str)
+pose_element = xmlr.Element('pose', Pose, False)
+
+class Entity(xmlr.Object):
+	def __init__(self, name = None, pose = None):
+		self.name = name
+		self.pose = pose
+
+xmlr.reflect(Entity, params = [
+	name_attribute,
+	pose_element
+	])
+
+
+class Inertia(xmlr.Object):
+	KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
+	
+	def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
+		self.ixx = ixx
+		self.ixy = ixy
+		self.ixz = ixz
+		self.iyy = iyy
+		self.iyz = iyz
+		self.izz = izz
+	
+	def to_matrix(self):
+		return [
+			[self.ixx, self.ixy, self.ixz],
+			[self.ixy, self.iyy, self.iyz],
+			[self.ixz, self.iyz, self.izz]]
+
+xmlr.reflect(Inertia, params = [xmlr.Element(key, float) for key in Inertia.KEYS])
+
+# Pretty much copy-paste... Better method?
+# Use multiple inheritance to separate the objects out so they are unique?
+class Inertial(xmlr.Object):
+	def __init__(self, mass = 0.0, inertia = None, pose=None):
+		self.mass = mass
+		self.inertia = inertia
+		self.pose = pose
+
+xmlr.reflect(Inertial, params = [
+	xmlr.Element('mass', float),
+	xmlr.Element('inertia', Inertia),
+	pose_element
+	])
+
+
+class Link(Entity):
+	def __init__(self, name = None, pose = None, inertial = None, kinematic = False):
+		Entity.__init__(self, name, pose)
+		self.inertial = inertial
+		self.kinematic = kinematic
+
+xmlr.reflect(Link, parent_cls = Entity, params = [
+	xmlr.Element('inertial', Inertial),
+	xmlr.Attribute('kinematic', bool, False),
+	xmlr.AggregateElement('visual', Visual, var = 'visuals'),
+	xmlr.AggregateElement('collision', Collision, var = 'collisions')
+	])
+
+
+class Model(Entity):
+	def __init__(self, name = None, pose=None):
+		Entity.__init__(self, name, pose)
+		self.links = []
+		self.joints = []
+		self.plugins = []
+
+xmlr.reflect(Model, parent_cls = Entity, params = [
+	xmlr.AggregateElement('link', Link, var = 'links'),
+	xmlr.AggregateElement('joint', Joint, var = 'joints'),
+	xmlr.AggregateElement('plugin', Plugin, var = 'plugins')
+	])
+
+xmlr.end_namespace('sdf')

--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/urdf.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/urdf.py
@@ -1,0 +1,578 @@
+from urdf_parser_py.xml_reflection.basics import *
+import urdf_parser_py.xml_reflection as xmlr
+
+# Add a 'namespace' for names so that things don't conflict between URDF and SDF?
+# A type registry? How to scope that? Just make a 'global' type pointer?
+# Or just qualify names? urdf.geometric, sdf.geometric
+
+xmlr.start_namespace('urdf')
+
+xmlr.add_type('element_link', xmlr.SimpleElementType('link', str))
+xmlr.add_type('element_xyz', xmlr.SimpleElementType('xyz', 'vector3'))
+
+verbose = True
+
+class Pose(xmlr.Object):
+	def __init__(self, xyz=None, rpy=None):
+		self.xyz = xyz
+		self.rpy = rpy
+	
+	def check_valid(self):
+		assert self.xyz is not None or self.rpy is not None
+	
+	# Aliases for backwards compatibility
+	@property
+	def rotation(self): return self.rpy
+	@rotation.setter
+	def rotation(self, value): self.rpy = value
+	@property
+	def position(self): return self.xyz
+	@position.setter
+	def position(self, value): self.xyz = value
+
+xmlr.reflect(Pose, params = [
+	xmlr.Attribute('xyz', 'vector3', False),
+	xmlr.Attribute('rpy', 'vector3', False)
+	])
+
+
+# Common stuff
+name_attribute = xmlr.Attribute('name', str)
+origin_element = xmlr.Element('origin', Pose, False)
+
+class Color(xmlr.Object):
+	def __init__(self, *args):
+		# What about named colors?
+		count = len(args)
+		if count == 4 or count == 3:
+			self.rgba = args
+		elif count == 1:
+			self.rgba = args[0]
+		elif count == 0:
+			self.rgba = None
+		if self.rgba is not None:
+			if len(self.rgba) == 3:
+				self.rgba += [1.]
+			if len(self.rgba) != 4:
+				raise Exception('Invalid color argument count')
+
+xmlr.reflect(Color, params = [
+	xmlr.Attribute('rgba', 'vector4')
+	])
+
+
+class JointDynamics(xmlr.Object):
+	def __init__(self, damping=None, friction=None):
+		self.damping = damping
+		self.friction = friction
+
+xmlr.reflect(JointDynamics, params = [
+	xmlr.Attribute('damping', float, False),
+	xmlr.Attribute('friction', float, False)
+	])
+
+
+class Box(xmlr.Object):
+	def __init__(self, size = None):
+		self.size = size
+
+xmlr.reflect(Box, params = [
+	xmlr.Attribute('size', 'vector3')
+	])
+
+
+class Cylinder(xmlr.Object):
+	def __init__(self, radius = 0.0, length = 0.0):
+		self.radius = radius
+		self.length = length
+
+xmlr.reflect(Cylinder, params = [
+	xmlr.Attribute('radius', float),
+	xmlr.Attribute('length', float)
+	])
+
+
+class Sphere(xmlr.Object):
+	def __init__(self, radius=0.0):
+		self.radius = radius
+
+xmlr.reflect(Sphere, params = [
+	xmlr.Attribute('radius', float)
+	])
+
+
+class Mesh(xmlr.Object):
+	def __init__(self, filename = None, scale = None):
+		self.filename = filename
+		self.scale = scale
+
+xmlr.reflect(Mesh, params = [
+	xmlr.Attribute('filename', str),
+	xmlr.Attribute('scale', 'vector3', required=False)
+	])
+
+
+class GeometricType(xmlr.ValueType):
+	def __init__(self):
+		self.factory = xmlr.FactoryType('geometric', {
+			'box': Box,
+			'cylinder': Cylinder,
+			'sphere': Sphere,
+			'mesh': Mesh
+			})
+	
+	def from_xml(self, node):
+		children = xml_children(node)
+		assert len(children) == 1, 'One element only for geometric'
+		return self.factory.from_xml(children[0])
+	
+	def write_xml(self, node, obj):
+		name = self.factory.get_name(obj)
+		child = node_add(node, name)
+		obj.write_xml(child)
+
+xmlr.add_type('geometric', GeometricType())
+
+class Collision(xmlr.Object):
+	def __init__(self, geometry = None, origin = None):
+		self.geometry = geometry
+		self.origin = origin
+
+xmlr.reflect(Collision, params = [
+	origin_element,
+	xmlr.Element('geometry', 'geometric')
+	])
+
+
+class Texture(xmlr.Object):
+	def __init__(self, filename = None):
+		self.filename = filename
+
+xmlr.reflect(Texture, params = [
+	xmlr.Attribute('filename', str)
+	])
+
+
+class Material(xmlr.Object):
+	def __init__(self, name=None, color=None, texture=None):
+		self.name = name
+		self.color = color
+		self.texture = texture
+	
+	def check_valid(self):
+		if self.color is None and self.texture is None:
+			xmlr.on_error("Material has neither a color nor texture")
+
+xmlr.reflect(Material, params = [
+	name_attribute,
+	xmlr.Element('color', Color, False),
+	xmlr.Element('texture', Texture, False)
+	])
+
+
+class Visual(xmlr.Object):
+	def __init__(self, geometry = None, material = None, origin = None):
+		self.geometry = geometry
+		self.material = material
+		self.origin = origin
+
+xmlr.reflect(Visual, params = [
+	origin_element,
+	xmlr.Element('geometry', 'geometric'),
+	xmlr.Element('material', Material, False)
+	])
+
+
+class Inertia(xmlr.Object):
+	KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
+	
+	def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
+		self.ixx = ixx
+		self.ixy = ixy
+		self.ixz = ixz
+		self.iyy = iyy
+		self.iyz = iyz
+		self.izz = izz
+	
+	def to_matrix(self):
+		return [
+			[self.ixx, self.ixy, self.ixz],
+			[self.ixy, self.iyy, self.iyz],
+			[self.ixz, self.iyz, self.izz]]
+
+xmlr.reflect(Inertia, params = [xmlr.Attribute(key, float) for key in Inertia.KEYS])
+
+
+class Inertial(xmlr.Object):
+	def __init__(self, mass = 0.0, inertia = None, origin=None):
+		self.mass = mass
+		self.inertia = inertia
+		self.origin = origin
+
+xmlr.reflect(Inertial, params = [
+	origin_element,
+	xmlr.Element('mass', 'element_value'),
+	xmlr.Element('inertia', Inertia, False)
+	])
+
+
+
+#FIXME: we are missing the reference position here.
+class JointCalibration(xmlr.Object):
+	def __init__(self, rising=None, falling=None):
+		self.rising = rising
+		self.falling = falling
+
+xmlr.reflect(JointCalibration, params = [
+	xmlr.Attribute('rising', float, False),
+	xmlr.Attribute('falling', float, False)
+	])
+
+class JointLimit(xmlr.Object):
+	def __init__(self, effort=None, velocity=None, lower=None, upper=None):
+		self.effort = effort
+		self.velocity = velocity
+		self.lower = lower
+		self.upper = upper
+
+xmlr.reflect(JointLimit, params = [
+	xmlr.Attribute('effort', float),
+	xmlr.Attribute('lower', float, False, 0),
+	xmlr.Attribute('upper', float, False, 0),
+	xmlr.Attribute('velocity', float)
+	])
+
+#FIXME: we are missing __str__ here.
+class JointMimic(xmlr.Object):
+	def __init__(self, joint_name=None, multiplier=None, offset=None):
+		self.joint = joint_name
+		self.multiplier = multiplier
+		self.offset = offset	
+
+xmlr.reflect(JointMimic, params = [
+	xmlr.Attribute('joint', str),
+	xmlr.Attribute('multiplier', float, False),
+	xmlr.Attribute('offset', float, False)
+	])
+
+class SafetyController(xmlr.Object):
+	def __init__(self, velocity=None, position=None, lower=None, upper=None):
+		self.k_velocity = velocity
+		self.k_position = position
+		self.soft_lower_limit = lower
+		self.soft_upper_limit = upper
+
+xmlr.reflect(SafetyController, params = [
+	xmlr.Attribute('k_velocity', float),
+	xmlr.Attribute('k_position', float, False, 0),
+	xmlr.Attribute('soft_lower_limit', float, False, 0),
+	xmlr.Attribute('soft_upper_limit', float, False, 0)
+	])
+
+class Joint(xmlr.Object):
+	TYPES = ['unknown', 'revolute', 'continuous', 'prismatic', 'floating', 'planar', 'fixed']
+
+	def __init__(self, name=None, parent=None, child=None, joint_type=None,
+			axis=None, origin=None,
+			limit=None, dynamics=None, safety_controller=None, calibration=None,
+			mimic=None):
+		self.name = name
+		self.parent = parent
+		self.child = child
+		self.type = joint_type
+		self.axis = axis
+		self.origin = origin
+		self.limit = limit
+		self.dynamics = dynamics
+		self.safety_controller = safety_controller
+		self.calibration = calibration
+		self.mimic = mimic
+	
+	def check_valid(self):
+		assert self.type in self.TYPES, "Invalid joint type: {}".format(self.type)
+	
+	# Aliases
+	@property
+	def joint_type(self): return self.type
+	@joint_type.setter
+	def joint_type(self, value): self.type = value
+
+xmlr.reflect(Joint, params = [
+	name_attribute,
+	xmlr.Attribute('type', str),
+	origin_element,
+	xmlr.Element('axis', 'element_xyz', False),
+	xmlr.Element('parent', 'element_link'),
+	xmlr.Element('child', 'element_link'),
+	xmlr.Element('limit', JointLimit, False),
+	xmlr.Element('dynamics', JointDynamics, False),
+	xmlr.Element('safety_controller', SafetyController, False),
+	xmlr.Element('calibration', JointCalibration, False),
+	xmlr.Element('mimic', JointMimic, False)
+	])
+
+
+class Link(xmlr.Object):
+	def __init__(self, name=None, visual=None, inertial=None, collision=None, origin = None):
+		self.name = name
+		self.visual = visual
+		self.inertial = inertial
+		self.collision = collision
+		self.origin = origin
+
+xmlr.reflect(Link, params = [
+	name_attribute,
+	origin_element,
+	xmlr.Element('inertial', Inertial, False),
+	xmlr.Element('visual', Visual, False),
+	xmlr.Element('collision', Collision, False)
+	])
+
+
+class Actuator(xmlr.Object):
+	def __init__(self, name = None, hardwareInterface = None, mechanicalReduction = 1):
+		self.name = name
+		self.hardwareInterface = None
+		self.mechanicalReduction = None
+
+xmlr.reflect(Actuator, tag = 'actuator', params = [
+		name_attribute,
+		xmlr.Element('hardwareInterface', str),
+		xmlr.Element('mechanicalReduction', float, required = False)
+		])
+
+class Transmission(xmlr.Object):
+	def __init__(self, name = None, joint = None, actuator = None):
+		self.name = name
+		self.joint = joint
+		self.actuator = actuator
+
+xmlr.reflect(Transmission, tag = 'new_transmission', params = [
+	name_attribute,
+	xmlr.Attribute('type', str),
+	xmlr.Element('joint', 'element_name'),
+	xmlr.Element('actuator', Actuator),
+	])
+
+class PR2Compensator(xmlr.Object):
+	def __init__(self, k_belt=4000.0, kd_motor=10.0, lambda_combined=0.0, lambda_joint=60.0, lambda_motor=60.0, mass_motor=0.05):
+		self.k_belt = k_belt
+		self.kd_motor = kd_motor
+		self.lambda_combined = lambda_combined
+		self.lambda_joint = lambda_joint
+		self.lambda_motor = lambda_motor
+		self.mass_motor = mass_motor
+
+xmlr.reflect(PR2Compensator, tag = 'compensator', params = [
+		xmlr.Attribute('k_belt', float),
+		xmlr.Attribute('kd_motor', float),
+		xmlr.Attribute('lambda_combined', float),
+		xmlr.Attribute('lambda_joint', float),
+		xmlr.Attribute('lambda_motor', float),
+		xmlr.Attribute('mass_motor', float)
+		])
+
+class PR2SimulatedActuatedJoint(xmlr.Object):
+	def __init__(self, name = None, simulated_reduction = 3000, passive_actuated_joint = None):
+		self.name = name
+		self.simulated_reduction = simulated_reduction
+		self.passive_actuated_joint = passive_actuated_joint
+
+xmlr.reflect(PR2SimulatedActuatedJoint, tag = 'simulated_actuated_joint', params = [
+		name_attribute,
+		xmlr.Attribute('simulated_reduction', float),
+		xmlr.Attribute('passive_actuated_joint', str, False)
+		])
+
+class PR2Transmission(xmlr.Object):
+	def __init__(self, name = None, joint = None, actuator = None, mechanicalReduction = None, compensator = None, simulated_actuated_joint = None):
+		self.name = name
+		self.joint = joint
+		self.actuator = actuator
+		self.mechanicalReduction = mechanicalReduction
+		self.compensator = compensator
+		self.simulated_actuated_joint = simulated_actuated_joint
+
+xmlr.reflect(PR2Transmission, tag = 'pr2_transmission', params = [
+	name_attribute,
+	xmlr.Attribute('type', str),
+	xmlr.Element('joint', 'element_name'),
+	xmlr.Element('actuator', 'element_name'),
+	xmlr.Element('mechanicalReduction', float),
+	xmlr.Element('compensator', PR2Compensator, False),
+	xmlr.Element('simulated_actuated_joint', PR2SimulatedActuatedJoint, False)
+	])
+
+class PR2Actuator(xmlr.Object):
+	def __init__(self, name = None, mechanicalReduction = 1):
+		self.name = name
+		self.mechanicalReduction = mechanicalReduction
+
+xmlr.reflect(PR2Actuator, tag = 'pr2_actuator', params = [
+	name_attribute,
+	xmlr.Attribute('mechanicalReduction', float)
+	])
+
+class PR2WristTransmission(xmlr.Object):
+	def __init__(self, name = None, type = None, rightActuator = None, leftActuator = None, flexJoint = None, rollJoint = None):
+		self.name = name
+		self.type = type
+                self.rightActuator = rightActuator
+                self.leftActuator = leftActuator
+                self.flexJoint = flexJoint
+                self.rollJoint = rollJoint
+
+xmlr.reflect(PR2WristTransmission, tag = 'pr2_wrist_transmission', params = [
+	name_attribute,
+	xmlr.Attribute('type', str),
+	xmlr.Element('rightActuator', PR2Actuator),
+	xmlr.Element('leftActuator', PR2Actuator),
+	xmlr.Element('flexJoint', PR2Actuator),
+	xmlr.Element('rollJoint', PR2Actuator)
+	])
+
+
+class PR2GapJoint(xmlr.Object):
+	def __init__(self, L0=0.0, a=0.0, b=0.0, gear_ratio=40.0, h=0.0, mechanical_reduction=1.0, name=None, phi0=0.5, r=0.0, screw_reduction=0.0, t0=0.0, theta0=0.0):
+		self.L0 = L0
+		self.a = a
+		self.b = b
+		self.gear_ratio = gear_ratio
+		self.h = h
+		self.mechanical_reduction = mechanical_reduction
+		self.name = name
+		self.phi0 = phi0
+		self.r = r
+		self.screw_reduction = screw_reduction
+		self.t0 = t0
+		self.theta0 = theta0
+
+xmlr.reflect(PR2GapJoint, tag = 'pr2_gap_joint', params = [
+		xmlr.Attribute('L0', float),
+		xmlr.Attribute('a', float),
+		xmlr.Attribute('b', float),
+		xmlr.Attribute('gear_ratio', float),
+		xmlr.Attribute('h', float),
+		xmlr.Attribute('mechanical_reduction', float),
+		xmlr.Attribute('name', str),
+		xmlr.Attribute('phi0', float),
+		xmlr.Attribute('r', float),
+		xmlr.Attribute('screw_reduction', float),
+		xmlr.Attribute('t0', float),
+		xmlr.Attribute('theta0', float)
+		])
+
+class PR2GripperTransmission(xmlr.Object):
+	def __init__(self, name = None, type = None, actuator  = None, gap_joint = None, use_simulated_gripper_joint = None, passive_joint = [], simulated_actuated_joint = None):
+		self.aggregate_init()
+		self.name = name
+		self.type = type
+                self.actuator = actuator
+                self.gap_joint = gap_joint
+                self.use_simulated_gripper_joint = use_simulated_gripper_joint
+                self.passive_joint = passive_joint
+                self.simulated_actuated_joint = simulated_actuated_joint
+
+xmlr.reflect(PR2GripperTransmission, tag = 'pr2_gripper_transmission', params = [
+	name_attribute,
+	xmlr.Attribute('type', str),
+	xmlr.Element('actuator', 'element_name'),
+	xmlr.Element('gap_joint', PR2GapJoint),
+	xmlr.Element('use_simulated_gripper_joint', 'element_name'),
+	xmlr.AggregateElement('passive_joint', 'element_name', 'passive_joint'),
+	xmlr.Element('simulated_actuated_joint', PR2SimulatedActuatedJoint),
+	])
+
+#xmlr.add_type('transmission', xmlr.DuckTypedFactory('transmission', [Transmission, PR2WristTransmission, PR2GripperTransmission]))
+xmlr.add_type('transmission', xmlr.DuckTypedFactory('transmission', [Transmission, PR2Transmission, PR2WristTransmission, PR2GripperTransmission]))
+
+
+class Robot(xmlr.Object):
+	def __init__(self, name = None):
+		self.aggregate_init()
+		
+		self.name = name
+		self.joints = []
+		self.links = []
+		self.materials = []
+		self.gazebos = []
+		self.transmissions = []
+		
+		self.joint_map = {}
+		self.link_map = {}
+
+		self.parent_map = {}
+		self.child_map = {}
+	
+	def add_aggregate(self, typeName, elem):
+		xmlr.Object.add_aggregate(self, typeName, elem)
+		
+		if typeName == 'joint':
+			joint = elem
+			self.joint_map[joint.name] = joint
+			self.parent_map[ joint.child ] = (joint.name, joint.parent)
+			if joint.parent in self.child_map:
+				self.child_map[joint.parent].append( (joint.name, joint.child) )
+			else:
+				self.child_map[joint.parent] = [ (joint.name, joint.child) ]
+		elif typeName == 'link':
+			link = elem
+			self.link_map[link.name] = link
+
+	def add_link(self, link):
+		self.add_aggregate('link', link)
+
+	def add_joint(self, joint):
+		self.add_aggregate('joint', joint)
+
+	def get_chain(self, root, tip, joints=True, links=True, fixed=True):
+		chain = []
+		if links:
+			chain.append(tip)
+		link = tip
+		while link != root:
+			(joint, parent) = self.parent_map[link]
+			if joints:
+				if fixed or self.joint_map[joint].joint_type != 'fixed':
+					chain.append(joint)
+			if links:
+				chain.append(parent)
+			link = parent
+		chain.reverse()
+		return chain
+
+	def get_root(self):
+		root = None
+		for link in self.link_map:
+			if link not in self.parent_map:
+				assert root is None, "Multiple roots detected, invalid URDF."
+				root = link
+		assert root is not None, "No roots detected, invalid URDF."
+		return root
+
+	@classmethod
+	def from_parameter_server(cls, key = 'robot_description'):
+		"""
+		Retrieve the robot model on the parameter server
+		and parse it to create a URDF robot structure.
+
+		Warning: this requires roscore to be running.
+		"""
+		# Could move this into xml_reflection
+		import rospy
+		return cls.from_xml_string(rospy.get_param(key))
+	
+xmlr.reflect(Robot, tag = 'robot', params = [
+# 	name_attribute,
+	xmlr.Attribute('name', str, False), # Is 'name' a required attribute?
+	xmlr.AggregateElement('link', Link),
+	xmlr.AggregateElement('joint', Joint),
+	xmlr.AggregateElement('gazebo', xmlr.RawType()),
+	xmlr.AggregateElement('transmission', 'transmission'),
+	xmlr.AggregateElement('material', Material)
+	])
+
+# Make an alias
+URDF = Robot
+
+xmlr.end_namespace()

--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/__init__.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/__init__.py
@@ -1,0 +1,1 @@
+from urdf_parser_py.xml_reflection.core import *

--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/basics.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/basics.py
@@ -1,0 +1,75 @@
+import string
+import yaml
+import collections
+from lxml import etree
+
+# Different implementations mix well it seems
+# @todo Do not use this?
+from xml.etree.ElementTree import ElementTree
+
+def xml_string(rootXml, addHeader = True):
+    # Meh
+    xmlString = etree.tostring(rootXml, pretty_print = True)
+    if addHeader:
+        xmlString = '<?xml version="1.0"?>\n' + xmlString
+    return xmlString
+
+def dict_sub(obj, keys):
+    return dict((key, obj[key]) for key in keys)
+
+def node_add(doc, sub):
+    if sub is None:
+        return None
+    if type(sub) == str:
+        return etree.SubElement(doc, sub)
+    elif isinstance(sub, etree._Element):
+        doc.append(sub) # This screws up the rest of the tree for prettyprint...
+        return sub
+    else:
+        raise Exception('Invalid sub value')
+
+def pfloat(x):
+    return str(x).rstrip('.') 
+
+def xml_children(node):
+    children = node.getchildren()
+    def predicate(node):
+        return not isinstance(node, etree._Comment)
+    return filter(predicate, children)
+
+def to_yaml(obj):
+    """ Simplify yaml representation for pretty printing """
+    # Is there a better way to do this by adding a representation with yaml.Dumper?
+    # Ordered dict: http://pyyaml.org/ticket/29#comment:11
+    if obj is None or type(obj) in [str, unicode]:
+        out = str(obj)
+    elif type(obj) in [int, float, bool]:
+        return obj
+    elif hasattr(obj, 'to_yaml'):
+        out = obj.to_yaml()
+    elif isinstance(obj, etree._Element):
+    	out = etree.tostring(obj, pretty_print = True)
+    elif type(obj) == dict:
+        out = {}
+        for (var, value) in obj.iteritems():
+            out[str(var)] = to_yaml(value)
+    elif hasattr(obj, 'tolist'):
+        # For numpy objects
+        out = to_yaml(obj.tolist())
+    elif isinstance(obj, collections.Iterable):
+        out = [to_yaml(item) for item in obj]
+    else:
+        out = str(obj)
+    return out
+
+class SelectiveReflection(object):
+	def get_refl_vars(self):
+		return vars(self).keys()
+
+class YamlReflection(SelectiveReflection):
+	def to_yaml(self):
+		raw = dict((var, getattr(self, var)) for var in self.get_refl_vars())
+		return to_yaml(raw)
+		
+	def __str__(self):
+		return yaml.dump(self.to_yaml()).rstrip() # Good idea? Will it remove other important things?

--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/core.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/core.py
@@ -1,0 +1,540 @@
+from urdf_parser_py.xml_reflection.basics import *
+import sys
+import copy
+
+# @todo Get rid of "import *"
+# @todo Make this work with decorators
+
+# Is this reflection or serialization? I think it's serialization...
+# Rename?
+
+# Do parent operations after, to allow child to 'override' parameters?
+	# Need to make sure that duplicate entires do not get into the 'unset*' lists
+
+def reflect(cls, *args, **kwargs):
+	""" Simple wrapper to add XML reflection to an xml_reflection.Object class """
+	cls.XML_REFL = Reflection(*args, **kwargs)
+
+# Rename 'write_xml' to 'write_xml' to have paired 'load/dump', and make 'pre_dump' and 'post_load'?
+# When dumping to yaml, include tag name?
+
+# How to incorporate line number and all that jazz?
+def on_error(message):
+	""" What to do on an error. This can be changed to raise an exception. """
+	print >>sys.stderr, message
+
+skip_default = True
+#defaultIfMatching = True # Not implemeneted yet
+
+# Registering Types
+value_types = {}
+value_type_prefix = '' 
+
+def start_namespace(namespace):
+	"""
+	Basic mechanism to prevent conflicts for string types for URDF and SDF
+	@note Does not handle nesting!
+	"""
+	global value_type_prefix
+	value_type_prefix = namespace + '.'
+
+def end_namespace():
+	global value_type_prefix
+	value_type_prefix = ''
+
+def add_type(key, value):
+	if isinstance(key, str):
+		key = value_type_prefix + key
+	assert key not in value_types
+	value_types[key] = value
+
+def get_type(cur_type):
+	""" Can wrap value types if needed """
+	if value_type_prefix and isinstance(cur_type, str):
+		# See if it exists in current 'namespace'
+		curKey = value_type_prefix + cur_type
+		value_type = value_types.get(curKey)
+	else:
+		value_type = None
+	if value_type is None:
+		# Try again, in 'global' scope
+		value_type = value_types.get(cur_type)
+	if value_type is None:
+		value_type = make_type(cur_type)
+		add_type(cur_type, value_type)
+	return value_type
+
+def make_type(cur_type):
+	if isinstance(cur_type, ValueType):
+		return cur_type
+	elif isinstance(cur_type, str):
+		if cur_type.startswith('vector'):
+			extra = cur_type[6:]
+			if extra:
+				count = float(extra)
+			else:
+				count = None
+			return VectorType(count)
+		else:
+			raise Exception("Invalid value type: {}".format(cur_type))
+	elif cur_type == list:
+		return ListType()
+	elif issubclass(cur_type, Object):
+		return ObjectType(cur_type)
+	elif cur_type in [str, float]:
+		return BasicType(cur_type)
+	else:
+		raise Exception("Invalid type: {}".format(cur_type))
+
+class ValueType(object):
+	""" Primitive value type """
+	def from_xml(self, node):
+		return self.from_string(node.text)
+	
+	def write_xml(self, node, value):
+		""" If type has 'write_xml', this function should expect to have it's own XML already created
+		i.e., In Axis.to_sdf(self, node), 'node' would be the 'axis' element.
+		@todo Add function that makes an XML node completely independently?"""
+		node.text = self.to_string(value)
+	
+	def equals(self, a, b):
+		return a == b
+
+class BasicType(ValueType):
+	def __init__(self, cur_type):
+		self.type = cur_type
+	def to_string(self, value):
+		return str(value)
+	def from_string(self, value):
+		return self.type(value)
+
+class ListType(ValueType):
+	def to_string(self, values):
+		return ' '.join(values)
+	def from_string(self, text):
+		return text.split()
+	def equals(self, aValues, bValues):
+		return len(aValues) == len(bValues) and all(a == b for (a, b) in zip(aValues, bValues))
+
+class VectorType(ListType):
+	def __init__(self, count = None):
+		self.count = count
+	
+	def check(self, values):
+		if self.count is not None:
+			assert len(values) == self.count, "Invalid vector length"
+	
+	def to_string(self, values):
+		self.check(values)
+		raw = map(str, values)
+		return ListType.to_string(self, raw)
+		
+	def from_string(self, text):
+		raw = ListType.from_string(self, text)
+		self.check(raw)
+		return map(float, raw)
+
+class RawType(ValueType):
+	""" Simple, raw XML value. Need to bugfix putting this back into a document """
+	def from_xml(self, node):
+		return node
+	
+	def write_xml(self, node, value):
+		#!!! HACK Trying to insert an element at root level seems to screw up pretty printing
+		children = xml_children(value)
+		map(node.append, children)
+
+class SimpleElementType(ValueType):
+	def __init__(self, attribute, value_type):
+		self.attribute = attribute
+		self.value_type = get_type(value_type)
+	def from_xml(self, node):
+		text = node.get(self.attribute)
+		return self.value_type.from_string(text)
+	def write_xml(self, node, value):
+		text = self.value_type.to_string(value)
+		node.set(self.attribute, text)
+
+class ObjectType(ValueType):
+	def __init__(self, cur_type):
+		self.type = cur_type
+		
+	def from_xml(self, node):
+		obj = self.type()
+		obj.read_xml(node)
+		return obj
+	
+	def write_xml(self, node, obj):
+		obj.write_xml(node)
+
+class FactoryType(ValueType):
+	def __init__(self, name, typeMap):
+		self.name = name
+		self.typeMap = typeMap
+		self.nameMap = {}
+		for (key, value) in typeMap.iteritems():
+			# Reverse lookup
+			self.nameMap[value] = key
+	
+	def from_xml(self, node):
+		cur_type = self.typeMap.get(node.tag)
+		if cur_type is None:
+			raise Exception("Invalid {} tag: {}".format(self.name, node.tag))
+		value_type = get_type(cur_type)
+		return value_type.from_xml(node)
+	
+	def get_name(self, obj):
+		cur_type = type(obj)
+		name = self.nameMap.get(cur_type)
+		if name is None:
+			raise Exception("Invalid {} type: {}".format(self.name, cur_type))
+		return name
+	
+	def write_xml(self, node, obj):
+		obj.write_xml(node)
+
+
+class DuckTypedFactory(ValueType):
+        def __init__(self, name, typeOrder):
+                self.name = name
+                assert len(typeOrder) > 0
+                self.type_order = typeOrder
+
+        def from_xml(self, node):
+                error_set = []
+                for value_type in self.type_order:
+                        try:
+                                return value_type.from_xml(node)
+                        except Exception as e:
+                                error_set.append((value_type, e))
+                # Should have returned, we encountered errors
+                out = "Could not perform duck-typed parsing."
+                for (value_type, e) in error_set:
+                        out += "\nValue Type: {}\nException: {}\n".format(value_type, e)
+                raise Exception(out)
+
+        def write_xml(self, node, obj):
+                obj.write_xml(node)
+
+class Param(object):
+	""" Mirroring Gazebo's SDF api
+	
+	@param xml_var: Xml name
+		@todo If the value_type is an object with a tag defined in it's reflection, allow it to act as the default tag name?
+	@param var: Python class variable name. By default it's the same as the XML name
+	"""
+	def __init__(self, xml_var, value_type, required = True, default = None, var = None):
+		self.xml_var = xml_var
+		if var is None:
+			self.var = xml_var
+		else:
+			self.var = var
+		self.type = None
+		self.value_type = get_type(value_type)
+		self.default = default
+		if required:
+			assert default is None, "Default does not make sense for a required field"
+		self.required = required
+		self.is_aggregate = False
+	
+	def set_default(self):
+		if self.required:
+			raise Exception("Required {} not set in XML: {}".format(self.type, self.xml_var))
+		elif not skip_default:
+			setattr(obj, self.var, self.default)
+
+class Attribute(Param):
+	def __init__(self, xml_var, value_type, required = True, default = None, var = None):
+		Param.__init__(self, xml_var, value_type, required, default, var)
+		self.type = 'attribute'
+	
+	def set_from_string(self, obj, value):
+		""" Node is the parent node in this case """
+		# Duplicate attributes cannot occur at this point
+		setattr(obj, self.var, self.value_type.from_string(value))
+		
+	def add_to_xml(self, obj, node):
+		value = getattr(obj, self.var)
+		# Do not set with default value if value is None
+		if value is None:
+			if self.required:
+				raise Exception("Required attribute not set in object: {}".format(self.var))
+			elif not skip_default:
+				value = self.default
+		# Allow value type to handle None?
+		if value is not None:
+			node.set(self.xml_var, self.value_type.to_string(value))
+
+# Add option if this requires a header? Like <joints> <joint/> .... </joints> ??? Not really... This would be a specific list type, not really aggregate
+
+class Element(Param):
+	def __init__(self, xml_var, value_type, required = True, default = None, var = None, is_raw = False):
+		Param.__init__(self, xml_var, value_type, required, default, var)
+		self.type = 'element'
+		self.is_raw = is_raw
+		
+	def set_from_xml(self, obj, node):
+		value = self.value_type.from_xml(node)
+		setattr(obj, self.var, value)
+	
+	def add_to_xml(self, obj, parent):
+		value = getattr(obj, self.xml_var)
+		if value is None:
+			if self.required:
+				raise Exception("Required element not defined in object: {}".format(self.var))
+			elif not skip_default:
+				value = self.default
+		if value is not None:
+			self.add_scalar_to_xml(parent, value)
+	
+	def add_scalar_to_xml(self, parent, value):
+		if self.is_raw:
+			node = parent
+		else:
+			node = node_add(parent, self.xml_var)
+		self.value_type.write_xml(node, value)
+
+
+class AggregateElement(Element):
+	def __init__(self, xml_var, value_type, var = None, is_raw = False):
+		if var is None:
+			var = xml_var + 's'
+		Element.__init__(self, xml_var, value_type, required = False, var = var, is_raw = is_raw)
+		self.is_aggregate = True
+		
+	def add_from_xml(self, obj, node):
+		value = self.value_type.from_xml(node)
+		obj.add_aggregate(self.xml_var, value)
+	
+	def set_default(self):
+		pass
+	
+
+class Info:
+	""" Small container for keeping track of what's been consumed """
+	def __init__(self, node):
+		self.attributes = node.attrib.keys()
+		self.children = xml_children(node)
+
+class Reflection(object):
+	def __init__(self, params = [], parent_cls = None, tag = None):
+		""" Construct a XML reflection thing
+		@param parent_cls: Parent class, to use it's reflection as well.
+		@param tag: Only necessary if you intend to use Object.write_xml_doc()
+			This does not override the name supplied in the reflection definition thing.
+		"""
+		if parent_cls is not None:
+			self.parent = parent_cls.XML_REFL
+		else:
+			self.parent = None
+		self.tag = tag
+		
+		# Laziness for now
+		attributes = []
+		elements = []
+		for param in params:
+			if isinstance(param, Element):
+				elements.append(param)
+			else:
+				attributes.append(param)
+		
+		self.vars = []
+		self.paramMap = {}
+		
+		self.attributes = attributes
+		self.attribute_map = {}
+		self.required_attribute_names = []
+		for attribute in attributes:
+			self.attribute_map[attribute.xml_var] = attribute
+			self.paramMap[attribute.xml_var] = attribute
+			self.vars.append(attribute.var)
+			if attribute.required:
+				self.required_attribute_names.append(attribute.xml_var)
+		
+		self.elements = []
+		self.element_map = {}
+		self.required_element_names = []
+		self.aggregates = []
+		self.scalars = []
+		self.scalarNames = []
+		for element in elements:
+			self.element_map[element.xml_var] = element
+			self.paramMap[element.xml_var] = element
+			self.vars.append(element.var)
+			if element.required:
+				self.required_element_names.append(element.xml_var)
+			if element.is_aggregate:
+				self.aggregates.append(element)
+			else:
+				self.scalars.append(element)
+				self.scalarNames.append(element.xml_var)
+	
+	def set_from_xml(self, obj, node, info = None):
+		is_final = False
+		if info is None:
+			is_final = True
+			info = Info(node)
+		
+		if self.parent:
+			self.parent.set_from_xml(obj, node, info)
+		
+		# Make this a map instead? Faster access? {name: isSet} ?
+		unset_attributes = self.attribute_map.keys()
+		unset_scalars = copy.copy(self.scalarNames)
+		
+		# Better method? Queues?
+		for xml_var in copy.copy(info.attributes):
+			attribute = self.attribute_map.get(xml_var)
+			if attribute is not None:
+				value = node.attrib[xml_var]
+				attribute.set_from_string(obj, value)
+				unset_attributes.remove(xml_var)
+				info.attributes.remove(xml_var)
+		
+		# Parse unconsumed nodes
+		for child in copy.copy(info.children):
+			tag = child.tag
+			element = self.element_map.get(tag)
+			if element is not None:
+				if element.is_aggregate:
+					element.add_from_xml(obj, child)
+				else:
+					if tag in unset_scalars:
+						element.set_from_xml(obj, child)
+						unset_scalars.remove(tag)
+					else:
+						on_error("Scalar element defined multiple times: {}".format(tag))
+				info.children.remove(child)
+		
+		for attribute in map(self.attribute_map.get, unset_attributes):
+			attribute.set_default()
+			
+		for element in map(self.element_map.get, unset_scalars):
+			element.set_default()
+		
+		if is_final:
+			for xml_var in info.attributes:
+				on_error('Unknown attribute: {}'.format(xml_var))
+			for node in info.children:
+				on_error('Unknown tag: {}'.format(node.tag))
+	
+	def add_to_xml(self, obj, node):
+		if self.parent:
+			self.parent.add_to_xml(obj, node)
+		for attribute in self.attributes:
+			attribute.add_to_xml(obj, node)
+		for element in self.scalars:
+			element.add_to_xml(obj, node)
+		# Now add in aggregates
+		if self.aggregates:
+			obj.add_aggregates_to_xml(node)
+
+class Object(YamlReflection):
+	""" Raw python object for yaml / xml representation """
+	XML_REFL = None
+	
+	def get_refl_vars(self):
+		return self.XML_REFL.vars
+	
+	def check_valid(self):
+		pass
+	
+	def pre_write_xml(self):
+		""" If anything needs to be converted prior to dumping to xml
+		i.e., getting the names of objects and such """
+		pass
+	
+	def write_xml(self, node):
+		""" Adds contents directly to XML node """
+		self.check_valid()
+		self.pre_write_xml()
+		self.XML_REFL.add_to_xml(self, node)
+	
+	def to_xml(self):
+		""" Creates an overarching tag and adds its contents to the node """
+		tag = self.XML_REFL.tag
+		assert tag is not None, "Must define 'tag' in reflection to use this function"
+		doc = etree.Element(tag)
+		self.write_xml(doc)
+		return doc
+	
+	def to_xml_string(self):
+		return xml_string(self.to_xml())
+	
+	def post_read_xml(self):
+		pass
+	
+	def read_xml(self, node):
+		self.XML_REFL.set_from_xml(self, node)
+		self.post_read_xml()
+		self.check_valid()
+		
+	@classmethod
+	def from_xml(cls, node):
+		cur_type = get_type(cls)
+		return cur_type.from_xml(node)
+	
+	@classmethod
+	def from_xml_string(cls, xml_string):
+		node = etree.fromstring(xml_string)
+		return cls.from_xml(node)
+	
+	@classmethod
+	def from_xml_file(cls, file_path):
+		xml_string= open(file_path, 'r').read()
+		return cls.from_xml_string(xml_string)
+
+	# Confusing distinction between loading code in object and reflection registry thing...
+
+	def get_aggregate_list(self, xml_var):
+		var = self.XML_REFL.paramMap[xml_var].var
+		values = getattr(self, var)
+		assert isinstance(values, list)
+		return values
+		
+	def aggregate_init(self):
+		""" Must be called in constructor! """
+		self.aggregate_order = []
+		# Store this info in the loaded object??? Nah
+		self.aggregate_type = {}
+		
+	def add_aggregate(self, xml_var, obj):
+		""" NOTE: One must keep careful track of aggregate types for this system.
+		Can use 'lump_aggregates()' before writing if you don't care. """
+		self.get_aggregate_list(xml_var).append(obj)
+		self.aggregate_order.append(obj)
+		self.aggregate_type[obj] = xml_var
+	
+	def add_aggregates_to_xml(self, node):
+		for value in self.aggregate_order:
+			typeName = self.aggregate_type[value]
+			element = self.XML_REFL.element_map[typeName]
+			element.add_scalar_to_xml(node, value)
+	
+	def remove_aggregate(self, obj):
+		self.aggregate_order.remove(obj)
+		xml_var = self.aggregate_type[obj]
+		del self.aggregate_type[obj]
+		self.get_aggregate_list(xml_var).remove(obj)
+	
+	def lump_aggregates(self):
+		""" Put all aggregate types together, just because """
+		self.aggregate_init()
+		for param in self.XML_REFL.aggregates:
+			for obj in self.get_aggregate_list(param.xml_var):
+				self.add_aggregate(param.var, obj)
+	
+	""" Compatibility """
+	def parse(self, xml_string):
+		node = etree.fromstring(xml_string)
+		self.read_xml(node)
+		return self
+
+# Really common types
+add_type('element_name', SimpleElementType('name', str))
+add_type('element_value', SimpleElementType('value', float))
+
+# Add in common vector types so they aren't absorbed into the namespaces
+get_type('vector3')
+get_type('vector4')
+get_type('vector6')


### PR DESCRIPTION
- add pr2_urdf_parser_py directory by copying from https://github.com/ros/urdfdom/pull/55
- overwrite PYTHONPATH when running multi_step_cov_estimator.py to use urdf_parser_py under pr2_urdf_parser_py directory instead of official urdf_parser_py
- You can test calibration by https://drive.google.com/file/d/0B4bnoIcbRJVuVWVqT1ExR0hvcEE/view?usp=sharing
