### PR TITLE
Add --camera-name arg to launch script

### DIFF
--- a/pr2_calibration_launch/intrinsics/calibrate_forearm_left.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_forearm_left.launch
@@ -1,6 +1,6 @@
 <launch>
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=5x4 --square=0.025"
+        args="--size=5x4 --square=0.025 --camera_name=l_forearm_cam"
         name="calibration_gui" output="screen">
     <remap from="image" to="l_forearm_cam/image_raw" />
     <remap from="camera" to="l_forearm_cam" />

--- a/pr2_calibration_launch/intrinsics/calibrate_forearm_right.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_forearm_right.launch
@@ -1,6 +1,6 @@
 <launch>
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=5x4 --square=0.025"
+        args="--size=5x4 --square=0.025 --camera_name=r_forearm_cam"
         name="calibration_gui" output="screen">
     <remap from="image" to="r_forearm_cam/image_raw" />
     <remap from="camera" to="r_forearm_cam" />

--- a/pr2_calibration_launch/intrinsics/calibrate_narrow_stereo.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_narrow_stereo.launch
@@ -1,6 +1,6 @@
 <launch>
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=7x6 --square=0.108"
+        args="--size=7x6 --square=0.108 --camera_name=narrow_stereo"
         name="calibration_gui" output="screen">
     <remap from="left" to="narrow_stereo/left/image_raw" />
     <remap from="right" to="narrow_stereo/right/image_raw" />

--- a/pr2_calibration_launch/intrinsics/calibrate_prosilica.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_prosilica.launch
@@ -5,7 +5,7 @@
   </node>
   
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=7x6 --square=0.108"
+        args="--size=7x6 --square=0.108 --camera_name=prosilica"
         name="calibration_gui" output="screen">
     <remap from="image" to="prosilica/image_raw" />
     <remap from="camera" to="prosilica" />

--- a/pr2_calibration_launch/intrinsics/calibrate_prosilica_kinect.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_prosilica_kinect.launch
@@ -1,6 +1,6 @@
 <launch> 
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=7x6 --square=0.108"
+        args="--size=7x6 --square=0.108 --camera_name=prosilica_kinect"
         name="calibration_gui" output="screen">
     <remap from="image" to="prosilica_kinect/image_raw" />
     <remap from="camera" to="prosilica_kinect" />

--- a/pr2_calibration_launch/intrinsics/calibrate_wide_stereo.launch
+++ b/pr2_calibration_launch/intrinsics/calibrate_wide_stereo.launch
@@ -1,6 +1,6 @@
 <launch>
   <node type="cameracalibrator.py" pkg="camera_calibration"
-        args="--size=7x6 --square=0.108"
+        args="--size=7x6 --square=0.108 --camera_name=wide_stereo"
         name="calibration_gui" output="screen">
     <remap from="left" to="wide_stereo/left/image_raw" />
     <remap from="right" to="wide_stereo/right/image_raw" />


### PR DESCRIPTION
The camera name is now needed by the camera calibration script.
