### PR TITLE
Fix for recovering python2 compatibility 

### DIFF
--- a/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/core.py
+++ b/pr2_calibration_launch/pr2_urdf_parser_py/urdf_parser_py/xml_reflection/core.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from urdf_parser_py.xml_reflection.basics import *
 import sys
 import copy


### PR DESCRIPTION
print(message, file=sys.stderr) introduced in https://github.com/PR2/pr2_calibration/pull/18 breaks the compatibility with python2x. 
```
def on_error(message):
	""" What to do on an error. This can be changed to raise an exception. """
	print(message, file=sys.stderr)
```

This PR recover the compatibility.